### PR TITLE
Remove Stream Key Property ID Default

### DIFF
--- a/tap_framework/streams.py
+++ b/tap_framework/streams.py
@@ -26,7 +26,7 @@ def is_selected(stream_catalog):
 class BaseStream:
     # GLOBAL PROPERTIES
     TABLE = None
-    KEY_PROPERTIES = ['id']
+    KEY_PROPERTIES = []
     API_METHOD = 'GET'
     REQUIRES = []
 


### PR DESCRIPTION
This removes the default `['id']` value for the `KEY_PROPERTY` attribute on a Stream object. The reasoning is that not all Streams will 1) enforce primary key constraints 2) have an ID field available.