### PR TITLE
Fallback on selected-by-default metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import os.path
 
 setup(name='tap-framework',
-      version='0.1.0',
+      version='0.1.1',
       description='Framework for building Singer.io taps',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/tap_framework/streams.py
+++ b/tap_framework/streams.py
@@ -12,7 +12,11 @@ def is_selected(stream_catalog):
     stream_metadata = metadata.get((), {})
 
     inclusion = stream_metadata.get('inclusion')
-    selected = stream_metadata.get('selected')
+
+    if stream_metadata.get('selected') is not None:
+        selected = stream_metadata.get('selected')
+    else:
+        selected = stream_metadata.get('selected-by-default')
 
     if inclusion == 'unsupported':
         return False


### PR DESCRIPTION
## Overview

This PR updates the `is_selected` function in the `streams` module to fallback on using `selected-by-default` metadata whenever `selected` isn't present. 

The rationale for this is based on [feedback](https://github.com/singer-io/tap-chargebee/pull/4#discussion_r280552036) I've received from @nick-mccoy that certain metadata fields, such as `selected`, are non-discoverable and thus should only ever be _**read**_ by a tap, not written by a tap. I've updated the streams in the chargebee tap to instead write `selected-by-default` to the metadata in the catalog, but this currently prevents the tap-framework from picking up the streams because of the lack of the `selected` metadata field.

This change should be a non-breaking change since it will still default to using `selected` metadata, if available in the catalog.