### PR TITLE
Bump singer-python from <5.2.0 to <5.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@ from setuptools import setup, find_packages
 import os.path
 
 setup(name='tap-framework',
-      version='0.1.1',
+      version='0.1.2',
       description='Framework for building Singer.io taps',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_framework'],
       install_requires=[
-          'singer-python>=5.1.0,<5.2.0',
+          'singer-python>=5.1.0,<5.5.0',
           'backoff==1.3.2',
           'requests==2.18.4',
           'requests-oauthlib==0.8.0',


### PR DESCRIPTION
* `singer-python>=5.4.0` includes support for `patternProperties` in JSON schemas: https://github.com/singer-io/singer-python/pull/92